### PR TITLE
Fix the inherited instance variables

### DIFF
--- a/lib/sequel_secure_password.rb
+++ b/lib/sequel_secure_password.rb
@@ -16,7 +16,7 @@ module Sequel
 
       module ClassMethods
         attr_reader :cost
-        Plugins.inherited_instance_variables(self, @cost => nil)
+        Plugins.inherited_instance_variables(self, :@cost => nil)
       end
 
       module InstanceMethods

--- a/spec/sequel_secure_password_spec.rb
+++ b/spec/sequel_secure_password_spec.rb
@@ -44,6 +44,10 @@ describe "model using Sequel::Plugins::SecurePassword" do
     it { should be_valid }
   end
 
+  it "has an inherited instance variable :@cost" do
+    expect( User.inherited_instance_variables ).to include(:@cost)
+  end
+
   describe "#authenticate" do
     let(:secret) { "foo" }
     before { user.password = secret }


### PR DESCRIPTION
The missing colon meant that the inherited_instance_variables hash contained {nil => nil}, this was causing problems in other plugins.
