### PR TITLE
Removes unnecessary validation

### DIFF
--- a/lib/sequel_secure_password.rb
+++ b/lib/sequel_secure_password.rb
@@ -47,8 +47,7 @@ module Sequel
           super
 
           if model.include_validations
-            errors.add :password, 'is not present'      if SecurePassword.blank_string? password_digest
-            errors.add :password, 'has no confirmation' if SecurePassword.blank_string? password_confirmation
+            errors.add :password, 'is not present'              if SecurePassword.blank_string?(password_digest)
             errors.add :password, 'doesn\'t match confirmation' if password != password_confirmation
           end
         end


### PR DESCRIPTION
No need to check presence of password_confirmation. If the user is changing their password then password isn't nil and thus won't match a password_confirmation that isn't present. If the user isn't changing their password then password is nil and thus password_confirmation should be too.
