### PR TITLE
Option for alternate digest columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ Or install it yourself as:
 
 ## Usage
 
-Plugin should be used in subclasses of `Sequel::Model`. The model should have
-`password_digest` attribute in database.
+Plugin should be used in subclasses of `Sequel::Model`.
 __Always__ call super in `validate` method of your model, otherwise password
 validations won't be executed.
 It __does not__ `set_allowed_columns` and mass assignment policy must be managed
@@ -43,6 +42,12 @@ Example model:
     # presence and confirmation
     class UserWithoutValidations < Sequel::Model
       plugin :secure_password, include_validations: false
+    end
+
+    # digest_column option can be used to use an alternate database column.
+    # the default column is "password_digest"
+    class UserWithAlternateDigestColumn < Sequel::Model
+      plugin :secure_password, digest_column: :password_hash
     end
 
     user = User.new

--- a/lib/sequel_secure_password/version.rb
+++ b/lib/sequel_secure_password/version.rb
@@ -1,3 +1,3 @@
 module SequelSecurePassword
-  VERSION = "0.2.10"
+  VERSION = "0.2.11"
 end

--- a/lib/sequel_secure_password/version.rb
+++ b/lib/sequel_secure_password/version.rb
@@ -1,3 +1,3 @@
 module SequelSecurePassword
-  VERSION = "0.2.9"
+  VERSION = "0.2.10"
 end

--- a/lib/sequel_secure_password/version.rb
+++ b/lib/sequel_secure_password/version.rb
@@ -1,3 +1,3 @@
 module SequelSecurePassword
-  VERSION = "0.2.8"
+  VERSION = "0.2.9"
 end

--- a/sequel_secure_password.gemspec
+++ b/sequel_secure_password.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |gem|
   gem.name          = "sequel_secure_password"
   gem.version       = SequelSecurePassword::VERSION
   gem.authors       = ["Mateusz Lenik"]
-  gem.email         = ["mt.lenik@gmail.com"]
+  gem.email         = ["gems@mlen.pl"]
   gem.description   = %q{Plugin adds authentication methods to Sequel models using BCrypt library.}
   gem.summary       = <<EOF
 Plugin adds BCrypt authentication and password hashing to Sequel models.

--- a/spec/sequel_secure_password_spec.rb
+++ b/spec/sequel_secure_password_spec.rb
@@ -52,6 +52,10 @@ describe "model using Sequel::Plugins::SecurePassword" do
     expect( User.inherited_instance_variables ).to include(:@include_validations)
   end
 
+  it "has an inherited instance variable :@digest_column" do
+    expect( User.inherited_instance_variables ).to include(:@digest_column)
+  end
+
   context "when validations are disabled" do
     subject(:user_without_validations) { UserWithoutValidations.new }
     before do
@@ -83,6 +87,16 @@ describe "model using Sequel::Plugins::SecurePassword" do
       before { highcost_user.password = "foo" }
       it {
         BCrypt::Password.new(highcost_user.password_digest).cost.should be 12
+      }
+    end
+  end
+
+  describe "with digest column option" do
+    subject(:digestcolumn_user) { UserWithAlternateDigestColumn.new }
+    context "having an alternate digest column" do
+      before { digestcolumn_user.password = "foo" }
+      it {
+        BCrypt::Password.new(digestcolumn_user.password_hash).should eq "foo"
       }
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,9 +39,19 @@ RSpec.configure do |c|
       plugin :secure_password, include_validations: false
     end
 
+    class UserWithAlternateDigestColumn < Sequel::Model
+      set_schema do
+        primary_key :id
+        varchar     :password_hash
+      end
+
+      plugin :secure_password, digest_column: :password_hash
+    end
+
     User.create_table!
     HighCostUser.create_table!
     UserWithoutValidations.create_table!
+    UserWithAlternateDigestColumn.create_table!
   end
 
   c.around :each do |example|


### PR DESCRIPTION
Adds an option to use an alternate column for storing password digests.

Needed it for a project with an existing database I wasn't allowed to migrate, thought I'd share.