### PR TITLE
Use configurable version of default cost

### DIFF
--- a/lib/sequel_secure_password.rb
+++ b/lib/sequel_secure_password.rb
@@ -15,7 +15,7 @@ module Sequel
       # confirmation validations won't be included. Default: true
       def self.configure(model, options = {})
         model.instance_eval do
-          @cost                = options.fetch(:cost, BCrypt::Engine::DEFAULT_COST)
+          @cost                = options.fetch(:cost, BCrypt::Engine.cost)
           @include_validations = options.fetch(:include_validations, true)
           @digest_column       = options.fetch(:digest_column, :password_digest)
         end


### PR DESCRIPTION
[`BCrypt::Engine.cost`](https://github.com/codahale/bcrypt-ruby/blob/1f9184a8df2b90fa02d01a32a364eefc9072e1b9/lib/bcrypt/engine.rb#L23) defaults to `BCrypt::Engine::DEFAULT_COST`, so the functionality is preserved.

I preferred this because for testing I would need to do

```rb
class User < Sequel::Model
  plugin :secure_password, cost: (ENV["RACK_ENV"] == "test" ? 1 : 10)
end
```

And I don't really like exposing testing environment in application code. On the other hand, I really like when I can just put in my `spec_helper.rb`


```rb
BCrypt::Engine.cost = 1
```